### PR TITLE
Fixed create_team to add correct mapping to dict

### DIFF
--- a/ghtools/migrators/teams.py
+++ b/ghtools/migrators/teams.py
@@ -26,7 +26,7 @@ class TeamMigrator(object):
                 'name': team['name'],
                 'permission': team['permission']
             }
-            self._dst_teams[team['name']] = self.dst.create_team(team)['id']
+            self._dst_teams[team['name']] = self.dst.create_team(team)
 
     def _migrate_members(self, team):
         for member in self.src.list_team_members(team):


### PR DESCRIPTION
Currently create_team method in teams.py was updating destination team dict with incorrect mapping of name to id which should now be name to team object.
