### PR TITLE
[#82935274] Upgrade requests library to version 2.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 from ghtools import __version__
 
 requirements = [
-    'requests==1.1.0',
+    'requests==2.2.1',
     'argh==0.23.0'
 ]
 


### PR DESCRIPTION
Upgrade the `requests` library to match the version provided by Ubuntu
Trusty, version 2.1.1.

This is to prevent a conflict on Ubuntu Trusty between system Python
libraries and Pip libraries.

Specifically, Pip relies on the `IncompleteRead` module that is exported
by `requests.compat`. Version 2.4.3 of the `requests` library removed
that exported module[1](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=766419).

When `ghtools` is installed, Pip would upgrade `requests` to version
2.4.3 (the latest available), thereby causing Pip to break because the
`requests` module installed by Pip (in
`/usr/lib/python2.7/dist-packages/`) takes precendence over the system
version of that module.

This was causing the following Puppet error on our ci-slave-4 box in Vagrant
using Ubuntu Trusty:

```
==> ci-slave-4: Error: Could not prefetch package provider 'pip': [nil, nil, [(provider=pip)], nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil]
```

When I tried to run `pip` on the Vagrant box, I got the following error:

```
vagrant@ci-slave-4:~$ pip
Traceback (most recent call last):
  File "/usr/bin/pip", line 9, in <module>
    load_entry_point('pip==1.5.4', 'console_scripts', 'pip')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 351, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2363, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2088, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
  File "/usr/lib/python2.7/dist-packages/pip/__init__.py", line 11, in <module>
    from pip.vcs import git, mercurial, subversion, bazaar  # noqa
  File "/usr/lib/python2.7/dist-packages/pip/vcs/mercurial.py", line 9, in <module>
    from pip.download import path_to_url
  File "/usr/lib/python2.7/dist-packages/pip/download.py", line 25, in <module>
    from requests.compat import IncompleteRead
ImportError: cannot import name IncompleteRead
vagrant@ci-slave-4:~$
```

By installing requiring the exact same version of `requests` as the one
provided by the system under Ubuntu Trusty, Pip no longer needs to
install the `requests` module and `ghtools` will use the system module.
This is also tested under Precise and does not break Pip.

I verified the version of `requests` installed on Ubuntu Trusty prior to
installing `ghtools`:

```
vagrant@jumpbox-2:~/ghtools$ python
Python 2.7.6 (default, Mar 22 2014, 22:59:56)
[GCC 4.8.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import requests
>>> print requests.__version__
2.2.1
>>>
```

When installing `ghtools`, Pip detects the existing system version and
will not install its own:

```
vagrant@jumpbox-2:~/ghtools$ sudo pip install .
Unpacking /home/vagrant/ghtools
  Running setup.py (path:/tmp/user/0/pip-0GLR1h-build/setup.py) egg_info for package from file:///home/vagrant/ghtools

Requirement already satisfied (use --upgrade to upgrade): requests==2.2.1 in /usr/lib/python2.7/dist-packages (from ghtools==0.21.0)
[...]
```

For more context, please see this bug report (though the bug is not in
python-pip):
https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1306991
