### PR TITLE
Add `context` arg to status command.

### DIFF
--- a/ghtools/command/status.py
+++ b/ghtools/command/status.py
@@ -16,6 +16,7 @@ parser = ArghParser(description="Set commit/branch build status")
 @arg('state', help='State to attach', choices=['pending', 'success', 'error', 'failure'])
 @arg('-d', '--description', help='Status description')
 @arg('-u', '--url', help='URL linking to status details')
+@arg('-c', '--context', help='Label to differentiate this status from the status of other systems')
 def status(args):
     """
     Set build status for a commit on GitHub
@@ -29,6 +30,9 @@ def status(args):
 
     if args.url is not None:
         payload['target_url'] = args.url
+
+    if args.context is not None:
+        payload['context'] = args.context
 
     with cli.catch_api_errors():
         res = repo.set_build_status(args.sha, payload)

--- a/test/unit/command/test_status.py
+++ b/test/unit/command/test_status.py
@@ -1,0 +1,34 @@
+from mock import patch
+from ghtools.command.status import status, parser
+
+
+class TestRepo(object):
+
+    def setup(self):
+        self.patcher = patch('ghtools.command.status.Repo')
+        self.mock_repo = self.patcher.start()
+        self.mock_repo.return_value.set_build_status.return_value.json.return_value = {}
+
+    def teardown(self):
+        self.patcher.stop()
+
+    def test_status(self):
+        args = parser.parse_args([
+            'alphagov/foobar',
+            'mybranch',
+            'pending',
+            '--description', 'Running on Jenkins',
+            '--url', 'http://ci.alphagov.co.uk/foo',
+            '--context', 'CI'
+        ])
+        status(args)
+        self.mock_repo.assert_called_with('alphagov/foobar')
+        self.mock_repo.return_value.set_build_status.assert_called_with(
+            'mybranch',
+            {
+                'state': 'pending',
+                'target_url': 'http://ci.alphagov.co.uk/foo',
+                'description': 'Running on Jenkins',
+                'context': 'CI'
+            }
+        )


### PR DESCRIPTION
This allows setting of multiple statuses on a pull request, as described here:
https://github.com/blog/1935-see-results-from-all-pull-request-status-checks